### PR TITLE
Implement `try_*` methods, remove unnecessary `backtrace` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+edition = "2021"
 name = "debug-cell"
 version = "0.1.1"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
@@ -14,7 +15,6 @@ where known borrows were created will be printed out as well.
 """
 
 [dependencies]
-backtrace = "0.3"
 
 [[test]]
 name = "smoke"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,9 +100,6 @@ pub mod error {
 }
 
 #[cfg(debug_assertions)]
-extern crate backtrace;
-
-#[cfg(debug_assertions)]
 use std::cell::RefCell as StdRefCell;
 use std::cell::{Cell, UnsafeCell};
 use std::ops::{Deref, DerefMut};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,77 @@
 //! // library's `RefCell`
 //! let b = r.borrow_mut();
 //! ```
-
 #![deny(missing_docs)]
+
+/// Error kind ported from nightly std
+pub mod error {
+    fn locations_display(locations: &[super::Location]) -> String {
+        locations
+            .iter()
+            .map(|location| format!("[{location}]"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+    /// An error returned by [`RefCell::try_borrow`].
+    #[non_exhaustive]
+    #[derive(Debug)]
+    pub struct BorrowError {
+        /// Debug-only location of attempted borrow
+        #[cfg(debug_assertions)]
+        pub attempted_at: super::Location,
+        /// Debug-only location of all current locations
+        #[cfg(debug_assertions)]
+        pub already_borrowed_at: Vec<super::Location>,
+    }
+
+    impl std::fmt::Display for BorrowError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            #[cfg(debug_assertions)]
+            {
+                write!(
+                    f,
+                    "Value is already borrowed mutably at [{}]",
+                    locations_display(&self.already_borrowed_at)
+                )
+            }
+            #[cfg(not(debug_assertions))]
+            {
+                write!(f, "Value is already borrowed mutably")
+            }
+        }
+    }
+
+    impl std::error::Error for BorrowMutError {}
+
+    /// An error returned by [`RefCell::try_borrow_mut`].
+    #[derive(Debug)]
+    #[non_exhaustive]
+    pub struct BorrowMutError {
+        /// Debug-only location of attempted borrow
+        #[cfg(debug_assertions)]
+        pub attempted_at: super::Location,
+        /// Debug-only locations of all current borrows
+        #[cfg(debug_assertions)]
+        pub already_borrowed_at: Vec<super::Location>,
+    }
+
+    impl std::fmt::Display for BorrowMutError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            #[cfg(debug_assertions)]
+            {
+                write!(
+                    f,
+                    "Value is already borrowed at [{}]",
+                    locations_display(&self.already_borrowed_at)
+                )
+            }
+            #[cfg(not(debug_assertions))]
+            {
+                write!(f, "Value is already borrowed")
+            }
+        }
+    }
+}
 
 #[cfg(debug_assertions)]
 extern crate backtrace;
@@ -48,7 +117,7 @@ pub struct RefCell<T: ?Sized> {
 type Location = ();
 
 #[cfg(debug_assertions)]
-type Location = backtrace::Backtrace;
+type Location = &'static std::panic::Location<'static>;
 
 /// An enumeration of values returned from the `state` method on a `RefCell<T>`.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
@@ -83,9 +152,10 @@ impl<T> RefCell<T> {
     }
 
     /// Consumes the `RefCell`, returning the wrapped value.
+    #[cfg_attr(debug_assertions, track_caller)]
     pub fn into_inner(self) -> T {
         debug_assert!(self.borrow.flag.get() == UNUSED);
-        unsafe { self.value.into_inner() }
+        self.value.into_inner()
     }
 }
 
@@ -99,6 +169,7 @@ impl<T: ?Sized> RefCell<T> {
     ///
     /// Panics if the value is currently mutably borrowed.
     #[cfg_attr(debug_assertions, inline(never))]
+    #[cfg_attr(debug_assertions, track_caller)]
     pub fn borrow<'a>(&'a self) -> Ref<'a, T> {
         match BorrowRef::new(&self.borrow) {
             Some(b) => Ref {
@@ -106,6 +177,37 @@ impl<T: ?Sized> RefCell<T> {
                 _borrow: b,
             },
             None => self.panic("mutably borrowed"),
+        }
+    }
+    /// Immutably borrows the wrapped value.
+    ///
+    /// The borrow lasts until the returned `Ref` exits scope. Multiple
+    /// immutable borrows can be taken out at the same time.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is currently mutably borrowed.
+    #[cfg_attr(debug_assertions, inline(never))]
+    #[cfg_attr(debug_assertions, track_caller)]
+    pub fn try_borrow<'a>(&'a self) -> Result<Ref<'a, T>, crate::error::BorrowError> {
+        match BorrowRef::new(&self.borrow) {
+            Some(b) => Ok(Ref {
+                _value: unsafe { &*self.value.get() },
+                _borrow: b,
+            }),
+            None => {
+                #[cfg(debug_assertions)]
+                {
+                    Err(crate::error::BorrowError {
+                        attempted_at: get_caller(),
+                        already_borrowed_at: self.borrow.locations.borrow().clone(),
+                    })
+                }
+                #[cfg(not(debug_assertions))]
+                {
+                    Err(crate::error::BorrowError {})
+                }
+            }
         }
     }
 
@@ -118,6 +220,7 @@ impl<T: ?Sized> RefCell<T> {
     ///
     /// Panics if the value is currently borrowed.
     #[cfg_attr(debug_assertions, inline(never))]
+    #[cfg_attr(debug_assertions, track_caller)]
     pub fn borrow_mut<'a>(&'a self) -> RefMut<'a, T> {
         match BorrowRefMut::new(&self.borrow) {
             Some(b) => RefMut {
@@ -125,6 +228,35 @@ impl<T: ?Sized> RefCell<T> {
                 _borrow: b,
             },
             None => self.panic("borrowed"),
+        }
+    }
+
+    /// Tries borrowing the wrapped value mutably.
+    ///
+    /// The borrow lasts until the returned `RefMut` exits scope. The value
+    /// cannot be borrowed while this borrow is active.
+    ///
+    #[cfg_attr(debug_assertions, inline(never))]
+    #[cfg_attr(debug_assertions, track_caller)]
+    pub fn try_borrow_mut<'a>(&'a self) -> Result<RefMut<'a, T>, error::BorrowMutError> {
+        match BorrowRefMut::new(&self.borrow) {
+            Some(b) => Ok(RefMut {
+                _value: unsafe { &mut *self.value.get() },
+                _borrow: b,
+            }),
+            None => {
+                #[cfg(debug_assertions)]
+                {
+                    Err(error::BorrowMutError {
+                        attempted_at: get_caller(),
+                        already_borrowed_at: self.borrow.locations.borrow().clone(),
+                    })
+                }
+                #[cfg(not(debug_assertions))]
+                {
+                    Err(error::BorrowMutError {})
+                }
+            }
         }
     }
 
@@ -145,7 +277,7 @@ impl<T: ?Sized> RefCell<T> {
             }
             msg.push_str("\n\n");
         }
-        panic!(msg)
+        panic!("{}", msg)
     }
 }
 
@@ -153,7 +285,9 @@ impl<T: ?Sized> RefCell<T> {
 impl BorrowFlag {
     #[inline]
     fn new() -> BorrowFlag {
-        BorrowFlag { flag: Cell::new(UNUSED) }
+        BorrowFlag {
+            flag: Cell::new(UNUSED),
+        }
     }
 
     #[inline]
@@ -185,10 +319,11 @@ impl BorrowFlag {
 #[inline]
 fn get_caller() -> Location {}
 
-#[inline(never)]
 #[cfg(debug_assertions)]
+#[inline(never)]
+#[track_caller]
 fn get_caller() -> Location {
-    backtrace::Backtrace::new()
+    std::panic::Location::caller()
 }
 
 unsafe impl<T: ?Sized> Send for RefCell<T> where T: Send {}
@@ -200,13 +335,12 @@ impl<T: Clone> Clone for RefCell<T> {
     }
 }
 
-impl<T:Default> Default for RefCell<T> {
+impl<T: Default> Default for RefCell<T> {
     #[inline]
     fn default() -> RefCell<T> {
         RefCell::new(Default::default())
     }
 }
-
 
 impl<T: ?Sized + PartialEq> PartialEq for RefCell<T> {
     #[inline]
@@ -226,7 +360,9 @@ impl<'b> BorrowRef<'b> {
     #[cfg_attr(not(debug_assertions), inline)]
     fn new(borrow: &'b BorrowFlag) -> Option<BorrowRef<'b>> {
         let flag = borrow.flag.get();
-        if flag == WRITING { return None }
+        if flag == WRITING {
+            return None;
+        }
         borrow.flag.set(flag + 1);
         borrow.push(get_caller());
         Some(BorrowRef { borrow: borrow })
@@ -255,7 +391,6 @@ pub struct Ref<'b, T: ?Sized + 'b> {
     _borrow: BorrowRef<'b>,
 }
 
-
 impl<'b, T: ?Sized> Deref for Ref<'b, T> {
     type Target = T;
     fn deref(&self) -> &T {
@@ -271,10 +406,12 @@ impl<'b> BorrowRefMut<'b> {
     #[cfg_attr(debug_assertions, inline(never))]
     #[cfg_attr(not(debug_assertions), inline)]
     fn new(borrow: &'b BorrowFlag) -> Option<BorrowRefMut<'b>> {
-        if borrow.flag.get() != UNUSED { return None }
+        if borrow.flag.get() != UNUSED {
+            return None;
+        }
         borrow.flag.set(WRITING);
         borrow.push(get_caller());
-        Some(BorrowRefMut { borrow: borrow })
+        Some(BorrowRefMut { borrow })
     }
 }
 
@@ -294,7 +431,6 @@ pub struct RefMut<'b, T: ?Sized + 'b> {
     _value: &'b mut T,
     _borrow: BorrowRefMut<'b>,
 }
-
 
 impl<'b, T: ?Sized> Deref for RefMut<'b, T> {
     type Target = T;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,26 +250,6 @@ impl<T: ?Sized> RefCell<T> {
             }
         }
     }
-
-    #[cfg(not(debug_assertions))]
-    fn panic(&self, msg: &str) -> ! {
-        panic!("RefCell<T> already {}", msg)
-    }
-
-    #[cfg(debug_assertions)]
-    #[allow(unused_must_use)]
-    fn panic(&self, msg: &str) -> ! {
-        let mut msg = format!("RefCell<T> already {}", msg);
-        let locations = self.borrow.locations.borrow();
-        if locations.len() > 0 {
-            msg.push_str("\ncurrent active borrows: \n");
-            for b in locations.iter() {
-                msg.push_str(&format!("-------------------------\n{}\n", b));
-            }
-            msg.push_str("\n\n");
-        }
-        panic!("{}", msg)
-    }
 }
 
 #[cfg(not(debug_assertions))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,7 +170,7 @@ impl<T: ?Sized> RefCell<T> {
     /// Panics if the value is currently mutably borrowed.
     #[cfg_attr(debug_assertions, inline(never))]
     #[cfg_attr(debug_assertions, track_caller)]
-    pub fn borrow<'a>(&'a self) -> Ref<'a, T> {
+    pub fn borrow(&self) -> Ref<'_, T> {
         match BorrowRef::new(&self.borrow) {
             Some(b) => Ref {
                 _value: unsafe { &*self.value.get() },
@@ -189,7 +189,7 @@ impl<T: ?Sized> RefCell<T> {
     /// Panics if the value is currently mutably borrowed.
     #[cfg_attr(debug_assertions, inline(never))]
     #[cfg_attr(debug_assertions, track_caller)]
-    pub fn try_borrow<'a>(&'a self) -> Result<Ref<'a, T>, crate::error::BorrowError> {
+    pub fn try_borrow(&self) -> Result<Ref<'_, T>, crate::error::BorrowError> {
         match BorrowRef::new(&self.borrow) {
             Some(b) => Ok(Ref {
                 _value: unsafe { &*self.value.get() },
@@ -221,7 +221,7 @@ impl<T: ?Sized> RefCell<T> {
     /// Panics if the value is currently borrowed.
     #[cfg_attr(debug_assertions, inline(never))]
     #[cfg_attr(debug_assertions, track_caller)]
-    pub fn borrow_mut<'a>(&'a self) -> RefMut<'a, T> {
+    pub fn borrow_mut(&self) -> RefMut<'_, T> {
         match BorrowRefMut::new(&self.borrow) {
             Some(b) => RefMut {
                 _value: unsafe { &mut *self.value.get() },
@@ -238,7 +238,7 @@ impl<T: ?Sized> RefCell<T> {
     ///
     #[cfg_attr(debug_assertions, inline(never))]
     #[cfg_attr(debug_assertions, track_caller)]
-    pub fn try_borrow_mut<'a>(&'a self) -> Result<RefMut<'a, T>, error::BorrowMutError> {
+    pub fn try_borrow_mut(&self) -> Result<RefMut<'_, T>, error::BorrowMutError> {
         match BorrowRefMut::new(&self.borrow) {
             Some(b) => Ok(RefMut {
                 _value: unsafe { &mut *self.value.get() },
@@ -365,7 +365,7 @@ impl<'b> BorrowRef<'b> {
         }
         borrow.flag.set(flag + 1);
         borrow.push(get_caller());
-        Some(BorrowRef { borrow: borrow })
+        Some(BorrowRef { borrow })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@
 
 /// Error kind ported from nightly std
 pub mod error {
+    #[cfg(debug_assertions)]
     fn locations_display(locations: &[super::Location]) -> String {
         locations
             .iter()
@@ -170,7 +171,11 @@ impl<T: ?Sized> RefCell<T> {
     pub fn borrow(&self) -> Ref<'_, T> {
         match self.try_borrow() {
             Ok(value) => value,
-            Err(message) => panic!("Borrowing immutably failed: {}", message),
+            Err(message) => panic!(
+                "Borrowing {} immutably failed: {}",
+                std::any::type_name::<Self>(),
+                message
+            ),
         }
     }
     /// Immutably borrows the wrapped value.
@@ -218,7 +223,11 @@ impl<T: ?Sized> RefCell<T> {
     pub fn borrow_mut(&self) -> RefMut<'_, T> {
         match self.try_borrow_mut() {
             Ok(value) => value,
-            Err(message) => panic!("Borrowing mutably failed: {}", message),
+            Err(message) => panic!(
+                "Borrowing {} mutably failed: {}",
+                std::any::type_name::<Self>(),
+                message
+            ),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,8 @@ pub mod error {
         pub already_borrowed_at: Vec<super::Location>,
     }
 
+    impl std::error::Error for BorrowError {}
+
     impl std::fmt::Display for BorrowError {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             #[cfg(debug_assertions)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,7 +270,7 @@ impl<T: ?Sized> RefCell<T> {
         if locations.len() > 0 {
             msg.push_str("\ncurrent active borrows: \n");
             for b in locations.iter() {
-                msg.push_str(&format!("-------------------------\n{:?}\n", b));
+                msg.push_str(&format!("-------------------------\n{}\n", b));
             }
             msg.push_str("\n\n");
         }
@@ -353,8 +353,9 @@ struct BorrowRef<'b> {
 }
 
 impl<'b> BorrowRef<'b> {
-    #[cfg_attr(debug_assertions, inline(never))]
     #[cfg_attr(not(debug_assertions), inline)]
+    #[cfg_attr(debug_assertions, inline(never))]
+    #[cfg_attr(debug_assertions, track_caller)]
     fn new(borrow: &'b BorrowFlag) -> Option<BorrowRef<'b>> {
         let flag = borrow.flag.get();
         if flag == WRITING {
@@ -400,8 +401,9 @@ struct BorrowRefMut<'b> {
 }
 
 impl<'b> BorrowRefMut<'b> {
-    #[cfg_attr(debug_assertions, inline(never))]
     #[cfg_attr(not(debug_assertions), inline)]
+    #[cfg_attr(debug_assertions, inline(never))]
+    #[cfg_attr(debug_assertions, track_caller)]
     fn new(borrow: &'b BorrowFlag) -> Option<BorrowRefMut<'b>> {
         if borrow.flag.get() != UNUSED {
             return None;


### PR DESCRIPTION
I hope it's not too much of a change - it would enable some pretty sweet debugging and error-handling scenarios for Dioxus. Let me know what you think.